### PR TITLE
Properly set action bar title on fragment change

### DIFF
--- a/app/src/main/java/io/github/dasspike/dailyquote/QuoteFragment.java
+++ b/app/src/main/java/io/github/dasspike/dailyquote/QuoteFragment.java
@@ -39,6 +39,7 @@ public class QuoteFragment extends Fragment {
     private RequestController requestController;
     private SwipeRefreshLayout swipeRefreshLayout;
     private String url;
+    private String title;
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
@@ -172,9 +173,14 @@ public class QuoteFragment extends Fragment {
      * @param title The text the action bar should display.
      */
     private void setActionBarTitle(String title) {
-        // TODO: Set title regarding ViewPager position
-        // Currently the fragment that is not yet visible in the ViewPager but already loaded
-        // can set the action bar title
+        this.title = title;
+        setActionBarTitle();
+    }
+
+    /**
+     * Sets the title of the action bar to the title of the current quote.
+     */
+    public void setActionBarTitle() {
         AppCompatActivity activity = (AppCompatActivity) getActivity();
         if (activity != null) {
             ActionBar actionBar = activity.getSupportActionBar();

--- a/app/src/main/java/io/github/dasspike/dailyquote/QuotePagerAdapter.java
+++ b/app/src/main/java/io/github/dasspike/dailyquote/QuotePagerAdapter.java
@@ -1,9 +1,11 @@
 package io.github.dasspike.dailyquote;
 
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentStatePagerAdapter;
+import android.view.ViewGroup;
 
 class QuotePagerAdapter extends FragmentStatePagerAdapter {
 
@@ -38,5 +40,13 @@ class QuotePagerAdapter extends FragmentStatePagerAdapter {
     @Override
     public CharSequence getPageTitle(int position) {
         return CATEGORIES[position];
+    }
+
+    @Override
+    public void setPrimaryItem(@NonNull ViewGroup container, int position, @NonNull Object object) {
+        super.setPrimaryItem(container, position, object);
+
+        QuoteFragment fragment = (QuoteFragment) object;
+        fragment.setActionBarTitle();
     }
 }


### PR DESCRIPTION
When merged, this PR will fix an issue with action bar titles when quotes are from different dates.